### PR TITLE
Add CDP session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,19 @@ const screenshot = await capture.sessions.action(sessionId, 'screenshot', {
 
 await capture.sessions.close(sessionId);
 ```
+
+### CDP Sessions
+
+```javascript
+import { Capture } from 'capture-node';
+
+const capture = new Capture(YOUR_API_KEY, YOUR_API_SECRET);
+
+const created = await capture.sessions.create({
+    maxTtlSeconds: 300,
+    cdp: true
+});
+const connectUrl = created.session.connectUrl;
+```
+
+CDP sessions cannot be combined with `proxy` or `bypassBotDetection`.

--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -238,6 +238,47 @@ describe("Sessions API", () => {
 		);
 	});
 
+	it("creates a CDP session with cdp enabled", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: true,
+			status: 201,
+			json: async () => ({
+				success: true,
+				session: {
+					id: "sess_cdp",
+					status: "active",
+					connectUrl: "wss://edge.capture.page/v1/sessions/sess_cdp/cdp",
+				},
+			}),
+		} as Response);
+		const client = new Capture("user_123", "secret");
+
+		const response = await client.sessions.create({
+			maxTtlSeconds: 300,
+			cdp: true,
+		});
+
+		expect(response).toEqual({
+			success: true,
+			session: {
+				id: "sess_cdp",
+				status: "active",
+				connectUrl: "wss://edge.capture.page/v1/sessions/sess_cdp/cdp",
+			},
+		});
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://edge.capture.page/v1/sessions",
+			{
+				method: "POST",
+				headers: {
+					Authorization: "Bearer dXNlcl8xMjM6c2VjcmV0",
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ maxTtlSeconds: 300, cdp: true }),
+			},
+		);
+	});
+
 	it("gets and closes sessions", async () => {
 		const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
 			ok: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type SessionOptions = {
 	maxTtlSeconds?: number;
 	proxy?: boolean;
 	bypassBotDetection?: boolean;
+	cdp?: boolean;
 };
 
 export type ActionPayload = Record<string, unknown>;


### PR DESCRIPTION
Basecamp To-Do: https://app.basecamp.com/5890597/buckets/40504560/todos/10004635981

Summary:
- Add cdp to typed session create options.
- Document CDP session creation and connectUrl usage.
- Add focused create-session serialization coverage.

Verification:
- npm test